### PR TITLE
Run CI build/test jobs on linux/mac/windows

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -4,8 +4,11 @@ on: [push, pull_request]
 
 jobs:
 
-  build:
-    runs-on: ubuntu-20.04
+  build-test:
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-10.15, windows-2019] # hardcode versions so we can reproduce
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
We must use MacOS 10.15 due to https://github.com/actions/virtual-environments/issues/2486