### PR TITLE
Remove locks when `merge()` operations are complete

### DIFF
--- a/pkg/depend/request_test.go
+++ b/pkg/depend/request_test.go
@@ -46,6 +46,10 @@ func TestMergeRequests(t *testing.T) {
 	if err = requests.Merge(); err != nil {
 		t.Fatal(err)
 	}
+
+	if len(requests.lockTable) != 0 {
+		t.Fatal("locks not released at end of merge")
+	}
 }
 
 func writeBranchLocalGitRepo(git_path string, file_name string, branch string) error {

--- a/pkg/depend/write.go
+++ b/pkg/depend/write.go
@@ -2,6 +2,10 @@ package depend
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/git-depend/git-depend/pkg/git"
@@ -9,15 +13,31 @@ import (
 
 var ref_lock_name string = "git-depend-lock"
 
+type lockref struct {
+	// The git object that the lock is pointing to
+	object string
+	// The actual note object representing the lock
+	noteObject string
+}
+
 // Lock allows us to safely write to a note.
-type Lock struct {
+type lock struct {
 	ID        string    `json:"Id"`
 	Timestamp time.Time `json:"Timestamp"`
 	cache     *git.Cache
+	lockref   lockref
 }
 
-// WriteLock will lock an individual repository.
-func (lock *Lock) WriteLock(node *Node) error {
+func NewLock(ID string, cache *git.Cache) *lock {
+	return &lock{
+		ID:        ID,
+		Timestamp: time.Now(),
+		cache:     cache,
+	}
+}
+
+// writeLock will lock an individual repository.
+func (lock *lock) writeLock(node *Node) error {
 	data, err := json.Marshal(lock)
 	if err != nil {
 		return err
@@ -27,5 +47,50 @@ func (lock *Lock) WriteLock(node *Node) error {
 		return err
 	}
 
-	return lock.cache.PushNotes(node.url, ref_lock_name)
+	if err = lock.cache.PushNotes(node.url, ref_lock_name); err != nil {
+		return err
+	}
+
+	if err = lock.populateLockRef(node); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (lock *lock) removeLock(node *Node) error {
+	if err := lock.populateLockRef(node); err != nil {
+		return err
+	}
+	if err := lock.cache.RemoveNotes(node.url, ref_lock_name, lock.lockref.object); err != nil {
+		return err
+	}
+	if err := lock.cache.PushNotes(node.url, ref_lock_name); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (lock *lock) populateLockRef(node *Node) error {
+	byte_s, err := lock.cache.ListNotes(node.url, ref_lock_name)
+	if err != nil {
+		return err
+	}
+	// For Windows compatability
+	noteRefs := regexp.MustCompile("\r\n|\n").Split(strings.TrimSpace(string(byte_s)), -1)
+	if len(noteRefs) > 1 {
+		lastRef := strings.Fields(noteRefs[len(noteRefs)-1])[1]
+		// TODO: This should be managed by an appropriate logging library
+		return errors.New(fmt.Sprintf("Number of locks in the repo > 1, lock used maps to git %s", lastRef))
+	}
+
+	for _, noteRef := range noteRefs {
+		n := strings.Fields(noteRef)
+		if len(n) != 2 {
+			return errors.New(fmt.Sprintf("Unparseable git note reference. Num of fields in list != 2 (%d)", len(n)))
+		}
+		lock.lockref.noteObject = n[0]
+		lock.lockref.object = n[1]
+	}
+
+	return nil
 }

--- a/pkg/git/cache.go
+++ b/pkg/git/cache.go
@@ -209,12 +209,12 @@ func (cache *Cache) PushNotes(url string, ref string) error {
 }
 
 // RemoveNotes from the repository.
-func (cache *Cache) RemoveNotes(url string, ref string) error {
+func (cache *Cache) RemoveNotes(url string, ref string, object string) error {
 	dir, err := cache.GetRepositoryDirectory(url)
 	if err != nil {
 		return err
 	}
-	return RemoveNotes(dir, ref)
+	return RemoveNotes(dir, ref, object)
 }
 
 // Merge will perform a rebase and merge with --ff-only to keep a clean history and push.

--- a/pkg/git/notes.go
+++ b/pkg/git/notes.go
@@ -35,8 +35,8 @@ func ShowNotes(directory string, ref string) ([]byte, error) {
 	return Notes(directory, ref, args)
 }
 
-func RemoveNotes(directory string, ref string) error {
-	args := []string{"remove"}
+func RemoveNotes(directory string, ref string, object string) error {
+	args := []string{"remove", object}
 	_, err := Notes(directory, ref, args)
 	return err
 }


### PR DESCRIPTION
`merge()` operations now remove locks once the actual merging of the commits is complete.

In order to do this, two things are accomplished
- `lock` objects now have knowledge of the git object that is mapped to the note representing the lock
- `requests` objects now contain a mapping of nodes to locks that are acquired, to facilitate their eventual removal.

I think with this, we should also consider making `WriteLocks` and `RemoveLocks` methods private, but happy to be wrong in this/defer this to a future PR.

Closes #15 